### PR TITLE
Add crystall1nedev's anisette server

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -51,6 +51,10 @@
         {
             "name": "Jayden's Server",
             "address": "https://ani.jaydenha.uk"
+        },
+        {
+            "name": "crystall1nedev's server",
+            "address": "https://anisette.crystall1ne.dev"
         }
     ]
 }


### PR DESCRIPTION
**NOTE:** My anisette server used to be included in SideStore before, but it was since dropped because I didn't get around to updating it to v3. I don't believe it was ever added to this repo, though.

Server software: `dadoum/anisette-v3-server`
Server location: `Denver, CO (residential)`
Server hardware: `HP EliteDesk 800 G4 USFF, UNRAID OS 7.1.4`
Server network: 1000 Mbps down, 400 Mbps up

- Server software is inside of the provided Docker container. When updates are available, my server my go down for a period of a few seconds to provide the latest version.
- Server hardware also serves as the central node for *all* of my infrastructure - websites, CI/CD, etc. Uptime is important to me too!
  - Currently have 23 days of uptime. Last reboot was manual.
- If able to, notifications will be issued for anisette server outages prior to the outage.
